### PR TITLE
Add optional `handle_error` function to Toniq.Worker module

### DIFF
--- a/test/toniq_test.exs
+++ b/test/toniq_test.exs
@@ -19,6 +19,19 @@ defmodule ToniqTest do
     end
   end
 
+  defmodule TestHandleErrorWorker do
+    use Toniq.Worker
+
+    def perform(data: number) do
+      send :toniq_test, :job_has_been_run
+      raise "fail"
+    end
+
+    def handle_error(job, error, stack) do
+      send :toniq_test, :error_handled
+    end
+  end
+
   defmodule TestNoArgumentsWorker do
     use Toniq.Worker
 
@@ -118,6 +131,14 @@ defmodule ToniqTest do
     assert Toniq.delete(job)
 
     assert Toniq.failed_jobs == []
+  end
+
+  @tag :capture_log
+  test "failed jobs can perform error handling" do
+    job = Toniq.enqueue(TestHandleErrorWorker, data: 10)
+    assert_receive :error_handled
+    assert_receive { :failed, _job }
+    assert Enum.count(Toniq.failed_jobs) == 1
   end
 
   test "can handle jobs from another VM for some actions (for easy administration of failed jobs)" do

--- a/test/toniq_test.exs
+++ b/test/toniq_test.exs
@@ -22,7 +22,7 @@ defmodule ToniqTest do
   defmodule TestHandleErrorWorker do
     use Toniq.Worker
 
-    def perform(data: number) do
+    def perform(_arg) do
       send :toniq_test, :job_has_been_run
       raise "fail"
     end
@@ -135,7 +135,7 @@ defmodule ToniqTest do
 
   @tag :capture_log
   test "failed jobs can perform error handling" do
-    job = Toniq.enqueue(TestHandleErrorWorker, data: 10)
+    job = Toniq.enqueue(TestHandleErrorWorker)
     assert_receive :error_handled
     assert_receive { :failed, _job }
     assert Enum.count(Toniq.failed_jobs) == 1


### PR DESCRIPTION
When a Toniq job fails, the behavior is simply to log the error. This PR makes logging the error the default behavior but allows any worker using the Toniq.Worker module to optionally define its own `handle_error` function to run instead.